### PR TITLE
fixed issue with not highlighting white or black colors in tailwindcss

### DIFF
--- a/lua/nvim-highlight-colors/color/utils.lua
+++ b/lua/nvim-highlight-colors/color/utils.lua
@@ -89,7 +89,7 @@ end
 
 function M.get_tailwind_named_color_patterns()
 	local tailwind_pattern = {}
-	table.insert(tailwind_pattern, patterns.tailwind_prefix .. "%-%a+%-%d+")
+	table.insert(tailwind_pattern, patterns.tailwind_prefix .. "%-%a+[%-%d+]*")
 
 	return tailwind_pattern
 end


### PR DESCRIPTION
The issue was caused by the regex that was only applying for classes like bg-slate-500 and etc. Simply modified it and now works fine with text-white or bg-black.