### PR TITLE
Fix regex bug

### DIFF
--- a/lua/nvim-highlight-colors/color/patterns.lua
+++ b/lua/nvim-highlight-colors/color/patterns.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 M.rgb_regex = "rgba?[(]+" .. string.rep("%s*%d+%s*", 3, "[,%s]") .. "[,%s/]?%s*%d*%.?%d*%s*[)]+"
-M.hex_regex = "#[%a%d]+[%a%d]+[%a%d]+"
-M.hex_0x_regex = "0x[%a%d]+[%a%d]+[%a%d]+"
+M.hex_regex = "#%x%x%x+"
+M.hex_0x_regex = "0x%x%x%x+"
 M.hsl_regex = "hsla?[(]+" .. string.rep("%s*%d?%.?%d+%%?d?e?g?t?u?r?n?%s*", 3, "[,%s]") .. "[%s,/]?%s*%d*%.?%d*%%?%s*[)]+"
 
 M.var_regex = "%-%-[%d%a-_]+"


### PR DESCRIPTION
Since the `hex_regex` was capturing any sequence of 3 or more alphanumeric characters, there were some random highlights enabled in any filetype, such as `#keyword` was highlighted as Keyword, `#identifier` as Identifier, `#include` as Include and so on. Using the `%x` class, which stands for any hexadecimal character, this issue is fixed.