### PR TITLE
Add support for colour names enclosed in quotation marks

### DIFF
--- a/lua/nvim-highlight-colors/buffer_utils.lua
+++ b/lua/nvim-highlight-colors/buffer_utils.lua
@@ -2,7 +2,7 @@ local table_utils = require "nvim-highlight-colors.table_utils"
 
 local M = {}
 
-M.color_usage_regex = "[:=]+%s*"
+M.color_usage_regex = "[:=]+%s*[\"']?"
 
 function M.get_buffer_contents(min_row, max_row)
 	return vim.api.nvim_buf_get_lines(0, min_row, max_row, false)

--- a/lua/nvim-highlight-colors/utils.lua
+++ b/lua/nvim-highlight-colors/utils.lua
@@ -20,7 +20,7 @@ function M.get_win_visible_rows(winid)
 end
 
 local function create_highlight_name(color_value)
-	return string.gsub(color_value, "#", ""):gsub("[(),%s%.-/%%=:]+", "")
+	return string.gsub(color_value, "#", ""):gsub("[(),%s%.-/%%=:\"']+", "")
 end
 
 function M.create_window(row, col, bg_color, row_offset, custom_colors)


### PR DESCRIPTION
Support quoted CSS colour names, e.g. colour defined in source code or JSON as strings.

![image](https://github.com/brenoprata10/nvim-highlight-colors/assets/1018413/5c68ee3c-59b9-47fc-a0c2-8dd3ad27c204)
