### PR TITLE
Fix turn on/off behavior

### DIFF
--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -10,7 +10,6 @@ local render_options = {
 	foreground = "foreground"
 }
 
-local load_on_start_up = false
 local row_offset = 2
 local windows = {}
 local is_loaded = false
@@ -143,7 +142,7 @@ function M.turn_off()
 end
 
 function M.setup(user_options)
-	load_on_start_up = true
+	is_loaded = true
 	if (user_options ~= nil and user_options ~= {}) then
 		for key, _ in pairs(user_options) do
 			if user_options[key] ~= nil then
@@ -163,25 +162,23 @@ end
 
 vim.api.nvim_create_autocmd({"TextChanged", "TextChangedI", "TextChangedP", "VimResized"}, {
 	callback = function ()
-		if not is_loaded then
-			return
+		if is_loaded then
+			M.turn_on()
 		end
-		M.turn_on()
 	end,
 })
 
 vim.api.nvim_create_autocmd({"WinScrolled"}, {
 	callback = function()
-		if not is_loaded then
-			return
+		if is_loaded then
+			M.update_windows_visibility()
 		end
-		M.update_windows_visibility()
 	end
 })
 
 vim.api.nvim_create_autocmd({"BufEnter"}, {
 	callback = function ()
-		if load_on_start_up == true then
+		if is_loaded then
 			M.turn_on()
 		end
 	end,


### PR DESCRIPTION
I noticed that running `require("nvim-highlight-colors").turnOff()` and then changing buffer, the color highlighting gets re-enabled due to this autocmd:

```lua
vim.api.nvim_create_autocmd({"BufEnter"}, {
  callback = function ()
    if load_on_start_up == true then
      M.turn_on()
    end
  end,
})
```

The problem is that it relies on the `load_on_start_up` variable, which is set to `true` in the `setup` function and it never changes after that. So I replaced all its occurrencies with `is_loaded`, which gets actually updated inside the `turn_on` and `turn_off` functions.

I also applied a minor style change to the other two autocmds, where I removed the redundant `not`/`return`.