### PR TITLE
fix: only highlight hex colours at word boundaries

### DIFF
--- a/lua/nvim-highlight-colors/color/patterns.lua
+++ b/lua/nvim-highlight-colors/color/patterns.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 M.rgb_regex = "rgba?[(]+" .. string.rep("%s*%d+%s*", 3, "[,%s]") .. "[,%s/]?%s*%d*%.?%d*%s*[)]+"
-M.hex_regex = "#%x%x%x+"
-M.hex_0x_regex = "0x%x%x%x+"
+M.hex_regex = "#%x%x%x+%f[^%w]"
+M.hex_0x_regex = "%f[%w]0x%x%x%x+%f[^%w]"
 M.hsl_regex = "hsla?[(]+" .. string.rep("%s*%d?%.?%d+%%?d?e?g?t?u?r?n?%s*", 3, "[,%s]") .. "[%s,/]?%s*%d*%.?%d*%%?%s*[)]+"
 
 M.var_regex = "%-%-[%d%a-_]+"

--- a/lua/nvim-highlight-colors/color/patterns.lua
+++ b/lua/nvim-highlight-colors/color/patterns.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 M.rgb_regex = "rgba?[(]+" .. string.rep("%s*%d+%s*", 3, "[,%s]") .. "[,%s/]?%s*%d*%.?%d*%s*[)]+"
-M.hex_regex = "#%x%x%x+%f[^%w]"
-M.hex_0x_regex = "%f[%w]0x%x%x%x+%f[^%w]"
+M.hex_regex = "#%x%x%x+%f[^%w_]"
+M.hex_0x_regex = "%f[%w_]0x%x%x%x+%f[^%w_]"
 M.hsl_regex = "hsla?[(]+" .. string.rep("%s*%d?%.?%d+%%?d?e?g?t?u?r?n?%s*", 3, "[,%s]") .. "[%s,/]?%s*%d*%.?%d*%%?%s*[)]+"
 
 M.var_regex = "%-%-[%d%a-_]+"


### PR DESCRIPTION
Currently, the plugin highlights colours within words, which gets especially annoying when editing files in languages like C/C++ which make large use of these (`#define`) (#43)

This PR enforces word boundaries around hex colours so that it doesn't highlight these, while still highlighting isolated colours

Old behaviour:
<img width="420" alt="Screenshot 2023-12-30 at 5 35 18 pm" src="https://github.com/brenoprata10/nvim-highlight-colors/assets/25019123/0ed90dca-ebe1-42a7-96ab-e581c6b1c77d">
<img width="270" alt="Screenshot 2023-12-30 at 5 44 09 pm" src="https://github.com/brenoprata10/nvim-highlight-colors/assets/25019123/005f5fcd-e60e-4daf-bd68-f16422ce00bc">

New behaviour:
<img width="418" alt="Screenshot 2023-12-30 at 5 36 59 pm" src="https://github.com/brenoprata10/nvim-highlight-colors/assets/25019123/835316d9-09f3-4aa1-8284-ba5d4e184626">
<img width="274" alt="Screenshot 2023-12-30 at 5 44 40 pm" src="https://github.com/brenoprata10/nvim-highlight-colors/assets/25019123/c2601e5d-d2f5-448d-bfe2-8aa42293dce0">

Uses a [frontier pattern](http://www.lua.org/manual/5.2/manual.html#6.4.1) to define the word boundaries

Fixes #43