### PR TITLE
feat: add `options.virtual_symbol`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,16 @@ lua require("nvim-highlight-colors").toggle()
 | Property |      Options      | Description
 |----------|:-------------:|:----------:|
 | render |  background(default), foreground, virtual | Changes how the colors will be rendered |
+| virtual_symbol |  string (defaults to `■`) | Changes the symbol used to render the colors in virtual mode |
 | enable_named_colors |  boolean(defaults to `true`) | Adds highlight to css color names |
 | enable_tailwind |  boolean(defaults to `false`) | Adds highlight to tailwind colors |
 | custom_colors | `Array<{label: string, color: string}>` | Adds custom colors based on declared label |
 
 Here is how you might use the options:
-```
-lua require("nvim-highlight-colors").setup {
+```lua
+require("nvim-highlight-colors").setup {
 	render = 'background', -- or 'foreground' or 'virtual'
+	virtual_symbol = '■',
 	enable_named_colors = true,
 	enable_tailwind = false,
 	custom_colors = {
@@ -74,3 +76,8 @@ Custom colors support:
 Tailwind CSS support:
 
 ![Screenshot from 2022-08-14 16-49-35](https://user-images.githubusercontent.com/26099427/184542562-855fcdd4-c08d-4805-b756-8cbbf442382f.png)
+
+Virtual text support:
+
+![Screenshot of nvim-highlight-colors rendering colors via virtual text](https://github.com/brenoprata10/nvim-highlight-colors/assets/1474821/1534a62b-7214-4344-8316-a687c6f9d709)
+

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -18,6 +18,7 @@ local options = {
 	enable_named_colors = true,
 	enable_tailwind = false,
 	custom_colors = nil,
+	virtual_symbol = "■",
 }
 
 local M = {}
@@ -73,7 +74,8 @@ function M.highlight_colors(min_row, max_row, active_buffer_id)
 			data.end_column,
 			data.value,
 			options.render,
-			options.custom_colors
+			options.custom_colors,
+			options.virtual_symbol
 		)
 	end
 end

--- a/lua/nvim-highlight-colors/utils.lua
+++ b/lua/nvim-highlight-colors/utils.lua
@@ -34,7 +34,7 @@ local function create_highlight_name(color_value)
 	return string.gsub(color_value, "#", ""):gsub("[(),%s%.-/%%=:\"']+", "")
 end
 
-function M.create_highlight(activeBufferId, ns_id, row, start_column, end_column, color, render_option, custom_colors)
+function M.create_highlight(activeBufferId, ns_id, row, start_column, end_column, color, render_option, custom_colors, virtual_symbol)
 	local highlight_group = create_highlight_name(color)
 	local color_value = colors.get_color_value(color, 2, custom_colors)
 
@@ -61,7 +61,7 @@ function M.create_highlight(activeBufferId, ns_id, row, start_column, end_column
 			row + 1,
 			start_column - 1,
 			{
-				virt_text = {{'■', vim.api.nvim_get_hl_id_by_name(highlight_group)}},
+				virt_text = {{virtual_symbol, vim.api.nvim_get_hl_id_by_name(highlight_group)}},
 			}
 		)
 		return


### PR DESCRIPTION
This pull request allows customising the virtual text symbol when using `render = 'virtual'`. Can't say I love the name `virtual_symbol`, perhaps you have a better suggestion.

If you do want to go forward with this feature, I'd be happy to add documentation for the virtual text behaviour, including this addition. No hard feelings if this is not something you want to support.

Thanks!