### PR TITLE
fix: virtual text highlight

### DIFF
--- a/lua/nvim-highlight-colors/utils.lua
+++ b/lua/nvim-highlight-colors/utils.lua
@@ -62,6 +62,7 @@ function M.create_highlight(activeBufferId, ns_id, row, start_column, end_column
 			start_column - 1,
 			{
 				virt_text = {{virtual_symbol, vim.api.nvim_get_hl_id_by_name(highlight_group)}},
+				hl_mode = "combine",
 			}
 		)
 		return


### PR DESCRIPTION
Fixes #63 

Managed to find the fix by looking at the code for [nvim-colorizer](https://github.com/NvChad/nvim-colorizer.lua)