### PR TITLE
Fix protection of accidental blob strings getting mached

### DIFF
--- a/lua/nvim-highlight-colors/buffer_utils.lua
+++ b/lua/nvim-highlight-colors/buffer_utils.lua
@@ -18,15 +18,17 @@ function M.get_positions_by_regex(patterns, min_row, max_row, active_buffer_id, 
 				local row = key + min_row - row_offset
 				local column_offset = M.get_column_offset(positions, match, row)
 				local pattern_without_usage_regex = M.remove_color_usage_pattern(match)
-				local start_column = vim.fn.match(value, pattern_without_usage_regex, column_offset)
-				local end_column = vim.fn.matchend(value, pattern_without_usage_regex, column_offset)
+				local valid_start, start_column = pcall(vim.fn.match, value, pattern_without_usage_regex, column_offset)
+				local valid_end, end_column = pcall(vim.fn.matchend, value, pattern_without_usage_regex, column_offset)
 
-				table.insert(positions, {
-					value = match,
-					row = row,
-					start_column = start_column,
-					end_column = end_column
-				})
+				if valid_start and valid_end then
+					table.insert(positions, {
+						value = match,
+						row = row,
+						start_column = start_column,
+						end_column = end_column,
+					})
+				end
 			end
 		end
 	end


### PR DESCRIPTION
I accidentally opened a PDF file in my neovim session and got flooded with a ton of errors. This seems to be an issue with trying to match a string that's actually a binary blob. I added a couple checks to safely ignore these types of errors without causing issues.