### PR TITLE
fix!: remove redundant space in virtual text

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require("nvim-highlight-colors").setup {
 	render = 'background',
 
 	---Set virtual symbol (requires render to be set to 'virtual')
-	virtual_symbol = '■',
+	virtual_symbol = '■ ',
 
 	---Highlight named colors, e.g. 'green'
 	enable_named_colors = true,

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -17,7 +17,7 @@ local options = {
 	enable_named_colors = true,
 	enable_tailwind = false,
 	custom_colors = nil,
-	virtual_symbol = "■",
+	virtual_symbol = "■ ",
 }
 
 local M = {}

--- a/lua/nvim-highlight-colors/utils.lua
+++ b/lua/nvim-highlight-colors/utils.lua
@@ -79,7 +79,7 @@ function M.create_highlight(active_buffer_id, ns_id, row, start_column, end_colu
 					{
 
 						virt_text_pos = virt_text_pos,
-						virt_text = {{is_virt_text_eol and virtual_symbol or virtual_symbol .. ' ', vim.api.nvim_get_hl_id_by_name(highlight_group)}},
+						virt_text = {{virtual_symbol, vim.api.nvim_get_hl_id_by_name(highlight_group)}},
 						hl_mode = "combine",
 					}
 				)


### PR DESCRIPTION
I want to set virtual symbol with `inline` render option. The current code automatically adds `' '` (space) after the symbol, but I want the exact one to insert.

This may become a breaking change, so we should add a note for this, perhaps.