### PR TITLE
Specify filetypes and assign custom options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,14 @@ require("nvim-highlight-colors").setup {
 	custom_colors = {
 		{ label = '%-%-theme%-primary%-color', color = '#0f1219' },
 		{ label = '%-%-theme%-secondary%-color', color = '#5a5d64' },
-	}
+	},
+
+    ---Highlight filetypes
+    ---Accepts filetypes as strings, or as named tables with custom options
+    ---e.g. `{ 'js', html = { enable_tailwind = true }, 'css' }`
+    filetypes = {
+        'all',
+    },
 }
 ```
 

--- a/lua/nvim-highlight-colors/table_utils.lua
+++ b/lua/nvim-highlight-colors/table_utils.lua
@@ -115,4 +115,13 @@ function M.filter(table_param, fun)
 	return results
 end
 
+function M.merge(table_param, incoming_table)
+	local result = vim.deepcopy(table_param)
+	for index, value in pairs(incoming_table or {}) do
+		result[index] = value
+	end
+
+	return result
+end
+
 return M


### PR DESCRIPTION
# Filetype options

Allows users to specify what filetypes are highlighted by the plugin, including the ability to override "default" / "global" options set at the top level of the config.


## Changes

- New setup option `filetypes`. This table accepts filetypes as strings (e.g. `"css"`), or as named tables containing overrides for the other options (e.g. `css = { enable_tailwind = true }`). The default value is `{ "all" }` which is a special case that enables highlighting for all files.

- During setup
    1. User-options are merged into the options table
    2. For each filetype
        - Save its `options` to the `filetype_options` table
        - Select a pattern for the autocmd
        - Create the autocmd

- When an autocmd is triggered it will check to see if the filetype has changed, and if so updates `options` using `filetype_options` (Note that if using the default config `{ "all" }` then the filetype never changes, it always resolves to `"all"`). Autocommands also now use patterns and have been assigned to a group.

- New table util function `merge(base, incoming)` that returns a copy of the base table after merging in the incoming table.
