### PR TITLE
Add opts to disable highlights for specific filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ require("nvim-highlight-colors").setup {
 		{ label = '%-%-theme%-primary%-color', color = '#0f1219' },
 		{ label = '%-%-theme%-secondary%-color', color = '#5a5d64' },
 	}
+
+    -- Exclude filetypes from highlighting
+    exclude = {}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ require("nvim-highlight-colors").setup {
 		{ label = '%-%-theme%-secondary%-color', color = '#5a5d64' },
 	}
 
-    -- Exclude filetypes from highlighting
-    exclude = {}
+ 	-- Exclude filetypes from highlighting
+  	exclude = {}
 }
 ```
 

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -111,7 +111,9 @@ end
 function M.refresh_highlights(active_buffer_id, should_clear_highlights)
 	local buffer_id = active_buffer_id ~= nil and active_buffer_id or 0
 
-    if not vim.api.nvim_buf_is_valid(active_buffer_id) or vim.tbl_contains(options.exclude, vim.bo[buffer_id].filetype) then
+    if not vim.api.nvim_buf_is_valid(active_buffer_id)
+        or vim.tbl_contains(options.exclude, vim.bo[buffer_id].filetype)
+        or vim.bo[buffer_id].buftype == "terminal" then
 		return
 	end
 

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -25,6 +25,7 @@ local options = {
 	virtual_symbol_prefix = "",
 	virtual_symbol_suffix = " ",
 	virtual_symbol_position = "inline",
+    exclude = {}
 }
 
 local M = {}
@@ -110,7 +111,7 @@ end
 function M.refresh_highlights(active_buffer_id, should_clear_highlights)
 	local buffer_id = active_buffer_id ~= nil and active_buffer_id or 0
 
-	if not vim.api.nvim_buf_is_valid(active_buffer_id) or vim.bo[buffer_id].buftype == "terminal" then
+    if not vim.api.nvim_buf_is_valid(active_buffer_id) or vim.tbl_contains(options.exclude, vim.bo[buffer_id].filetype) then
 		return
 	end
 

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -111,11 +111,11 @@ end
 function M.refresh_highlights(active_buffer_id, should_clear_highlights)
 	local buffer_id = active_buffer_id ~= nil and active_buffer_id or 0
 
-    if not vim.api.nvim_buf_is_valid(active_buffer_id)
-        or vim.tbl_contains(options.exclude, vim.bo[buffer_id].filetype)
-        or vim.bo[buffer_id].buftype == "terminal" then
-		return
-	end
+ 	if not vim.api.nvim_buf_is_valid(active_buffer_id)
+ 		or vim.tbl_contains(options.exclude, vim.bo[buffer_id].filetype)
+ 		or vim.bo[buffer_id].buftype == "terminal" then
+ 		return
+ 	end
 
 	if should_clear_highlights then
 		M.clear_highlights(buffer_id)


### PR DESCRIPTION
Hello,

I've added an exclude option in the setup.

This option acts as a filter to exclude specific file types, such as lazy, notify, and alpha. The implementation is straightforward: it checks if the user has specified any file types to exclude, and if the current file type matches one of these, it disables highlights for the active buffer.

If anything needs to be changed, do not hesitate to tell me.

Thanks