### PR TITLE
feat!: allow excluding filetypes and buftypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ require("nvim-highlight-colors").setup {
 		{ label = '%-%-theme%-secondary%-color', color = '#5a5d64' },
 	}
 
- 	-- Exclude filetypes from highlighting
-  	exclude = {}
+ 	-- Exclude filetypes or buftypes from highlighting
+ 	-- Note: terminal buffers are always excluded due to instability
+  	exclude = {
+  		filetypes = {},
+  		buftypes = {},
+  	}
 }
 ```
 

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -26,7 +26,10 @@ local options = {
 	virtual_symbol_prefix = "",
 	virtual_symbol_suffix = " ",
 	virtual_symbol_position = "inline",
-    exclude = {}
+	exclude = {
+		filetypes = {},
+		buftypes = {},
+	}
 }
 
 local M = {}
@@ -113,8 +116,9 @@ function M.refresh_highlights(active_buffer_id, should_clear_highlights)
 	local buffer_id = active_buffer_id ~= nil and active_buffer_id or 0
 
  	if not vim.api.nvim_buf_is_valid(active_buffer_id)
- 		or vim.tbl_contains(options.exclude, vim.bo[buffer_id].filetype)
- 		or vim.bo[buffer_id].buftype == "terminal" then
+ 		or vim.bo[buffer_id].buftype == "terminal"
+ 		or vim.tbl_contains(options.exclude.filetypes, vim.bo[buffer_id].filetype)
+ 		or vim.tbl_contains(options.exclude.buftypes, vim.bo[buffer_id].buftype)
  		return
  	end
 


### PR DESCRIPTION
This allows the user to configure excluded buftypes as well and makes the default exclusion for "terminal" buffers