### PR TITLE
fix: use `tbl_deep_extend` now that user configuration is nested

### DIFF
--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -36,12 +36,8 @@ local M = {}
 
 function M.setup(user_options)
 	is_loaded = true
-	if (user_options ~= nil and user_options ~= {}) then
-		for key, _ in pairs(user_options) do
-			if user_options[key] ~= nil then
-				options[key] = user_options[key]
-			end
-		end
+	if user_options ~= nil and not vim.tbl_isempty(user_options) then
+		options = vim.tbl_deep_extend("force", options, user_options)
 	end
 end
 


### PR DESCRIPTION
Now that the configuration table is nested the basic loop approach is not valid. It would require the user to supply the entire `exclude = { filetypes = {}, buftypes = {} }` to have a valid config. This utilizes the core neovim api for table merging which handles this