### PR TITLE
Fix highlight collisions

### DIFF
--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -197,8 +197,8 @@ function M.format(entry, item)
 		return item
 	end
 
-	local highlight_group = utils.create_highlight_name(color_hex)
-	vim.api.nvim_set_hl(0, highlight_group, {fg = color_hex})
+	local highlight_group = utils.create_highlight_name("fg-" .. color_hex)
+	vim.api.nvim_set_hl(0, highlight_group, { fg = color_hex, default = true })
 
 	item.abbr_hl_group = highlight_group
 	item.abbr = options.virtual_symbol

--- a/lua/nvim-highlight-colors/utils.lua
+++ b/lua/nvim-highlight-colors/utils.lua
@@ -49,7 +49,7 @@ end
 ---* `label`: A string representing a template for the color name, likely using placeholders for the theme name. (e.g., '%-%-theme%-primary%-color')
 ---* `color`: A string representing the actual color value in a valid format (e.g., '#0f1219').
 function M.create_highlight(active_buffer_id, ns_id, data, options)
-	local highlight_group = M.create_highlight_name(data.value)
+	local highlight_group
 	local color_value = colors.get_color_value(data.value, 2, options.custom_colors, options.enable_short_hex)
 
 	if color_value == nil then
@@ -58,14 +58,18 @@ function M.create_highlight(active_buffer_id, ns_id, data, options)
 
 	if options.render == M.render_options.background then
 		local foreground_color = colors.get_foreground_color_from_hex_color(color_value)
+		highlight_group = M.create_highlight_name("fg-bg-" .. data.value)
 		pcall(vim.api.nvim_set_hl, 0, highlight_group, {
-            		fg = foreground_color,
-            		bg = color_value
-        	})
+			fg = foreground_color,
+			bg = color_value,
+			default = true,
+		})
 	else
+		highlight_group = M.create_highlight_name("fg-" .. data.value)
 		pcall(vim.api.nvim_set_hl, 0, highlight_group, {
-            		fg = color_value
-        	})
+			fg = color_value,
+			default = true,
+		})
 	end
 
 	if options.render == M.render_options.virtual then


### PR DESCRIPTION
Fixes #110

Currently the highlight groups for the highlighting in the document collide with the highlight groups set in the `cmp` formatting function. This is totally fine if the user doesn't use the background highlighting but if they do then it will mess up the highlighting on both. This does a few things: 

1. Makes sure the highlight names only collide if they provide the same highlight group `fg` vs `fg-bg`
2. uses `default = true` to make sure that if the highlight group already exists it doesn't get overwritten, this technically will save performance on each display