### PR TITLE
Add is_active command

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,12 @@ require("nvim-highlight-colors").setup {
 
 ## Commands
 
-| Command                   | Description         |
-| :------------------------ | :------------------ |
-| `:HighlightColors On`     | Turn highlights on  |
-| `:HighlightColors Off`    | Turn highlights off |
-| `:HighlightColors Toggle` | Toggle highlights   |
+| Command                     | Description                  |
+| :-------------------------- | :--------------------------- |
+| `:HighlightColors On`       | Turn highlights on           |
+| `:HighlightColors Off`      | Turn highlights off          |
+| `:HighlightColors Toggle`   | Toggle highlights            |
+| `:HighlightColors IsActive` | Highlights active / disabled |
 
 Commands are also available in lua:
 
@@ -171,4 +172,5 @@ Commands are also available in lua:
 require("nvim-highlight-colors").turnOn()
 require("nvim-highlight-colors").turnOff()
 require("nvim-highlight-colors").toggle()
+require("nvim-highlight-colors").is_active()
 ```

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -244,6 +244,11 @@ function M.toggle()
 	end
 end
 
+---Callback to get the current on/off state of the plugin.
+function M.is_active()
+	return is_loaded
+end
+
 ---Autocmd callback to handle changes that require a complete redraw of the highlights (clear current highlights + highlight again)
 ---@param props {buf: number}
 function M.handle_change_autocmd_callback(props)
@@ -286,12 +291,14 @@ vim.api.nvim_create_user_command("HighlightColors",
 			M.turn_off()
 		elseif arg == "toggle" then
 			M.toggle()
+		elseif arg == "isactive" then
+			M.is_active()
 		end
 	end,
 	{
 		nargs = 1,
 		complete = function()
-			return { "On", "Off", "Toggle" }
+			return { "On", "Off", "Toggle", "IsActive" }
 		end,
 		desc = "Config color highlight"
 	}
@@ -302,5 +309,6 @@ return {
 	turnOn = M.turn_on,
 	setup = M.setup,
 	toggle = M.toggle,
+	is_active = M.is_active,
 	format = M.format,
 }


### PR DESCRIPTION
This command allows users to easily find out, programmatically, if the plugin is actively highlighting colors codes or not.

Made as a follow up to https://github.com/brenoprata10/nvim-highlight-colors/issues/129

Feel free to rename the command or change the code in whichever way you like.