### PR TITLE
Remove use of deprecated `get_completion_item` and allow direct passing of an entry documentation

### DIFF
--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -188,12 +188,7 @@ function M.format(entry, item)
 		return item
 	end
 
-	local entryItem = entry:get_completion_item()
-	if entryItem == nil then
-		return item
-	end
-
-	local entryDoc = entryItem.documentation
+	local entryDoc = type(entry) ~= "table" and entry or vim.tbl_get(entry, "completion_item", "documentation")
 	if entryDoc == nil or type(entryDoc) ~= "string" then
 		return item
 	end


### PR DESCRIPTION
This removes the usage of a deprecated function in `nvim-cmp` and instead directly retrieves the `completion_item`. This also allows the entry to be passed in directly as a string to allow supporting the formatting of other completion engines like `blink.cmp`