### PR TITLE
Add documentation on `blink.cmp` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,47 @@ require("cmp").setup({
 })
 ```
 
+### `blink.cmp` integration
+
+```lua
+require("blink.cmp").setup {
+	completion = {
+		menu = {
+			draw = {
+				components = {
+					-- customize the drawing of kind icons
+					kind_icon = {
+						text = function(ctx)
+						  -- default kind icon
+						  local icon = ctx.kind_icon
+							-- if LSP source, check for color derived from documentation
+							if ctx.item.source_name == "LSP" then
+								local color_item = require("nvim-highlight-colors").format(ctx.item.documentation, { kind = ctx.kind })
+								if color_item and color_item.abbr then
+								  icon = color_item.abbr
+								end
+							end
+							return icon .. ctx.icon_gap
+						end,
+						highlight = function(ctx)
+							-- default highlight group
+							local highlight = "BlinkCmpKind" .. ctx.kind
+							-- if LSP source, check for color derived from documentation
+							if ctx.item.source_name == "LSP" then
+								local color_item = require("nvim-highlight-colors").format(ctx.item.documentation, { kind = ctx.kind })
+								if color_item and color_item.abbr_hl_group then
+								  highlight = color_item.abbr_hl_group
+								end
+							end
+							return highlight
+						end,
+					},
+				},
+			},
+		},
+	},
+}
+```
 
 ## Options
 

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -188,8 +188,11 @@ function M.format(entry, item)
 		return item
 	end
 
-	local entryDoc = type(entry) ~= "table" and entry or vim.tbl_get(entry or {}, "completion_item", "documentation")
-	if entryDoc == nil or type(entryDoc) ~= "string" then
+	local entryDoc = entry
+	if type(entryDoc) == "table" then
+		entryDoc = vim.tbl_get(entry or {}, "completion_item", "documentation")
+	end
+	if type(entryDoc) ~= "string" then
 		return item
 	end
 


### PR DESCRIPTION
This adds an example for `blink.cmp` integration to the README to help users get started. I also did some refactoring and performance improvements to the documentation retrieval while putting this together.