### PR TITLE
Add `exclude_buffer` configuration function for calculating if buffer should be enabeld

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ require("nvim-highlight-colors").setup {
 
  	-- Exclude filetypes or buftypes from highlighting e.g. 'exclude_buftypes = {'text'}'
     	exclude_filetypes = {},
-    	exclude_buftypes = {}
+    	exclude_buftypes = {},
+ 	-- Exclude buffer from highlighting e.g. 'exclude_buffer = function(bufnr) return vim.fn.getfsize(vim.api.nvim_buf_get_name(bufnr)) > 1000000 end'
+    	exclude_buffer = function(bufnr) end
 }
 ```
 

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -28,7 +28,8 @@ local options = {
 	virtual_symbol_suffix = " ",
 	virtual_symbol_position = "inline",
 	exclude_filetypes = {},
-	exclude_buftypes = {}
+	exclude_buftypes = {},
+	exclude_buffer = function(bufnr) end
 }
 
 local M = {}
@@ -128,6 +129,7 @@ function M.refresh_highlights(active_buffer_id, should_clear_highlights)
  		or vim.bo[buffer_id].buftype == "terminal"
  		or vim.tbl_contains(options.exclude_filetypes, vim.bo[buffer_id].filetype)
  		or vim.tbl_contains(options.exclude_buftypes, vim.bo[buffer_id].buftype)
+ 		or (options.exclude_buffer and options.exclude_buffer(buffer_id))
   	then
  		return
  	end


### PR DESCRIPTION
This adds a new configuration option for setting a function to calculate if a buffer should be excluded or not. This could be used to implement the same stuff as `exclude_buftypes` or `exclude_filetypes`, but also enables more logic such as disabling for files above a certain size.