### PR TITLE
docs(blink.cmp): correct color display logic for LSP completion items

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ require("blink.cmp").setup {
 							-- if LSP source, check for color derived from documentation
 							if ctx.item.source_name == "LSP" then
 								local color_item = require("nvim-highlight-colors").format(ctx.item.documentation, { kind = ctx.kind })
-								if color_item and color_item.abbr then
+								if color_item and color_item.abbr ~= "" then
 								  icon = color_item.abbr
 								end
 							end


### PR DESCRIPTION
When I set up blink.cmp according to the README, I encountered an issue where all LSP kind icons disappeared. After investigating, I found the problem appears to be in this code:

```lua
if color_item and color_item.abbr then
  icon = color_item.abbr
end
```

The issue occurs because `color_item.abbr` was returning an empty string, causing the condition to be true and overwriting `icon` with that empty string. As a result, no icons were displayed when `ctx.item.source_name` was `LSP`.

### Before fix

![before fix](https://github.com/user-attachments/assets/14f02b4f-7ebc-4e3d-a8be-77fd422b46d1)

### After fix

![after fix](https://github.com/user-attachments/assets/ffb56684-92e2-4a2a-aa61-ebc236705a05)