### PR TITLE
add transform function + remove_usage_pattern to custom colors

### DIFF
--- a/lua/nvim-highlight-colors/buffer_utils.lua
+++ b/lua/nvim-highlight-colors/buffer_utils.lua
@@ -34,12 +34,17 @@ function M.get_positions_by_regex(patterns, min_row, max_row, active_buffer_id, 
 	local positions = {}
 	local content = M.get_buffer_contents(min_row, max_row, active_buffer_id)
 
-	for _, pattern in pairs(patterns) do
+	for _, pattern_entry in pairs(patterns) do
+		local pattern = pattern_entry
+		if type(pattern_entry) == "table" then
+			-- custom colors use a table to pass an optional .remove_usage_pattern
+			pattern = pattern_entry[1]
+		end
 		for key, value in pairs(content) do
 			for match in string.gmatch(value, pattern) do
 				local row = key + min_row - row_offset
 				local column_offset = M.get_column_offset(positions, match, row)
-				local pattern_without_usage_regex = M.remove_color_usage_pattern(match)
+				local pattern_without_usage_regex = (pattern_entry.remove_usage_pattern or M.remove_color_usage_pattern)(match)
 				local valid_start, start_column = pcall(vim.fn.match, value, pattern_without_usage_regex, column_offset)
 				local valid_end, end_column = pcall(vim.fn.matchend, value, pattern_without_usage_regex, column_offset)
 				local isFalsePositiveCSSVariable = match == ': var'

--- a/lua/nvim-highlight-colors/color/patterns.lua
+++ b/lua/nvim-highlight-colors/color/patterns.lua
@@ -79,11 +79,16 @@ end
 
 ---Checks whether a color is a custom color
 ---@param color string
+---@param custom_colors {label: string, color?: string, transform?: fun(input:string):string|nil}[]
 ---@usage is_custom_color("custom-color", {{label = 'custom%-color', color = '#FFFFFF'}}) => Returns true
 ---@return boolean
 function M.is_custom_color(color, custom_colors)
 	for _, custom_color in pairs(custom_colors) do
-		if color == custom_color.label:gsub("%%", "") then
+		if custom_color.transform ~= nil then
+			if color:match(custom_color.label) ~= nil then
+				return true
+			end
+		elseif color == custom_color.label:gsub("%%", "") then
 			return true
 		end
 	end

--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -104,7 +104,8 @@ function M.highlight_colors(min_row, max_row, active_buffer_id)
 
 	if (options.custom_colors ~= nil) then
 		for _, custom_color in pairs(options.custom_colors) do
-			table.insert(patterns, custom_color.label)
+			custom_color[1] = custom_color.label
+			table.insert(patterns, custom_color)
 		end
 	end
 

--- a/lua/nvim-highlight-colors/utils.lua
+++ b/lua/nvim-highlight-colors/utils.lua
@@ -39,7 +39,7 @@ end
 ---@usage create_highlight_name("#FFFFFF") => Returns "nvim-highlight-colors-FFFFFF"
 ---@return string
 function M.create_highlight_name(color_value)
-	return 'nvim-highlight-colors-' .. string.gsub(color_value, "#", ""):gsub("\\[0-9]*%[", ""):gsub("[!(),%s%.-/%%=:\"'%%[%];#]+", "")
+	return 'nvim-highlight-colors-' .. string.gsub(color_value, "#", ""):gsub("\\[0-9]*%[", ""):gsub("[!(),%s%.-/%%=:\"'%%[%];#<>]+", "")
 end
 
 ---Creates the highlight based on the received params
@@ -50,7 +50,9 @@ end
 ---
 ---For `options.custom_colors`, a table with the following structure is expected:
 ---* `label`: A string representing a template for the color name, likely using placeholders for the theme name. (e.g., '%-%-theme%-primary%-color')
----* `color`: A string representing the actual color value in a valid format (e.g., '#0f1219').
+---* `color` (optional): A string representing the actual color value in a valid format (e.g., '#0f1219')
+---* `transform` (optional): A function to transform a matched template into a valid HEX color
+---One of `color` or `transform` is required.
 function M.create_highlight(active_buffer_id, ns_id, data, options)
 	local color_value = colors.get_color_value(data.value, 2, options.custom_colors, options.enable_short_hex)
 


### PR DESCRIPTION
* Allows more complex custom colors
* Can avoid having many custom color `label`s to iterate over, and instead use a map to lookup colors for a custom pattern

Example use case:
```lua
custom_colors = {
  {
    label = "NamedColors%.%w+",
    remove_usage_pattern = function(input)
      return input:sub(13)
    end,
    transform = function(input)
      return named_colors[input:sub(13)]
    end,
  },
}
```