### PR TITLE
fix: add dash character to hex regex boundaries

### DIFF
--- a/lua/nvim-highlight-colors/color/patterns.lua
+++ b/lua/nvim-highlight-colors/color/patterns.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.rgb_regex = "rgba?[(]+" .. string.rep("%s*%d+%s*", 3, "[,%s]") .. "[,%s/]?%s*%d*%.?%d*%%?%s*[)]+"
-M.hex_regex = "#%x%x%x+%f[^%w_]"
+M.hex_regex = "#%x%x%x+%f[^%w_-]"
 M.hex_0x_regex = "%f[%w_]0x%x%x%x+%f[^%w_]"
 M.hsl_regex = "hsla?[(]+" .. string.rep("%s*%d*%.?%d+%%?d?e?g?t?u?r?n?%s*", 3, "[,%s]") .. "[%s,/]?%s*%d*%.?%d*%%?%s*[)]+"
 -- Matches: `: 0 69% 69%`


### PR DESCRIPTION
Had an issue where i named an html id `#add-something`, which matched a short hex color when referenced in css/js ! 
Adding `-` to the hex regex seems to fix it. Where there any reason to not include it ? 

Thanks for this super nice plugin !