### PR TITLE
fix: create textDocument/documentColor param from active buffer id

### DIFF
--- a/lua/nvim-highlight-colors/utils.lua
+++ b/lua/nvim-highlight-colors/utils.lua
@@ -199,7 +199,7 @@ end
 ---@param positions {row: number, start_column: number, end_column: number, value: string}[]
 ---@param options {custom_colors: table, render: string, virtual_symbol: string, virtual_symbol_prefix: string, virtual_symbol_suffix: string, virtual_symbol_position: 'inline' | 'eol' | 'eow', enable_short_hex: boolean}
 function M.highlight_with_lsp(active_buffer_id, ns_id, positions, options)
-	local param = { textDocument = vim.lsp.util.make_text_document_params() }
+	local param = { textDocument = vim.lsp.util.make_text_document_params(active_buffer_id) }
 	local clients = M.get_lsp_clients(active_buffer_id)
 
 	for _, client in pairs(clients) do


### PR DESCRIPTION
```lua
local param = { textDocument = vim.lsp.util.make_text_document_params() }
```
creates the text document params for the currently active buffer

```lua
function M.highlight_with_lsp(active_buffer_id, ns_id, positions, options)
```
is called from autocommands (such as `LspAttach`). The buffer corresponding to the autocommand (which is passed through as `active_buffer_id`) might not be the currently active buffer and `vim.lsp.util.make_text_document_params()` may fail to produce a correct file URI. If such an invalid URI is send as a request to a LSP, that might even crash the LSP if it doesn't handle this error case, e.g. by logging and ignoring it (like with tinymist - see Myriad-Dreamin/tinymist/issues/1614)

I reproduced this bug with [AstroNvim](https://github.com/AstroNvim/AstroNvim), the [typst language pack](https://github.com/AstroNvim/astrocommunity/tree/80b9c580686610784667f1261392b989f62b580a/lua/astrocommunity/pack/typst) and [https://github.com/AstroNvim/astrocommunity/tree/383f86e1fca91adc013fd99dd4a4a01777471f3e/lua/astrocommunity/file-explorer/mini-files](minifiles). I cloned a [typst project](https://github.com/ChHecker/unify) for a test where I did the following
1. run `nvim init.typ`
2. opened the mini files explorer (active buffer file name is `minifiles://${BUFFER_ID}${PATH_TO_PROJECT_DIR})`)
3. open `lib.typ` in the files explorer (mini files explorer buffer stays active, `lib.typ` is opened in the background and the LSP attaches to a buffer whose file name is `${PATH_TO_PROJECT_DIR}/lib.typ`)

this leads to the following chain of events:
1. `param` is created for `minifiles://${BUFFER_ID}${PATH_TO_PROJECT_DIR})` which is not a valid file URL
2. the request is sent to the LSP (tinymist)
3. tinymist can't parse the URI, tries to unwrap the result (Rust) without checking for validity and crashes

The fix is very simple, we use `active_buffer_id` to create the correct params for our request with `vim.lsp.util.make_text_document_params(active_buffer_id)`

resolves #123 