### PR TITLE
fix: refresh highlights on setup to improve lazy loading

### DIFF
--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -47,6 +47,7 @@ function M.setup(user_options)
 			end
 		end
 	end
+	vim.tbl_map(function(bufnr) M.refresh_highlights(bufnr, true) end, vim.api.nvim_list_bufs())
 end
 
 ---Highlight visible colors within specified buffer id


### PR DESCRIPTION
This automatically calls refresh colors when running the setup for the plugin on the current buffers. This helps if the plugin is lazy loaded and at the point of setup the plugin is loaded and enabled.