### PR TITLE
fix: filter loaded buffers before refreshing highlights on setup

### DIFF
--- a/lua/nvim-highlight-colors/init.lua
+++ b/lua/nvim-highlight-colors/init.lua
@@ -49,7 +49,10 @@ function M.setup(user_options)
 			end
 		end
 	end
-	vim.tbl_map(function(bufnr) M.refresh_highlights(bufnr, true) end, vim.api.nvim_list_bufs())
+	vim.tbl_map(
+		function(bufnr) M.refresh_highlights(bufnr, true) end,
+		vim.tbl_filter(vim.api.nvim_buf_is_loaded, vim.api.nvim_list_bufs())
+	)
 end
 
 ---Highlight visible colors within specified buffer id


### PR DESCRIPTION
## Summary

Calling `refresh_highlights` on unloaded buffers in `setup()` crashes with
`bad argument #1 to 'pairs' (table expected, got nil)` because
`vim.api.nvim_buf_get_lines` can return `nil` for buffers that are valid but
not yet loaded.

This PR filters `nvim_list_bufs()` through `vim.api.nvim_buf_is_loaded` so
the iteration introduced in #172 only touches loaded buffers, preserving the
original intent (re-highlighting already-open buffers on lazy-load) without
crashing on buffers that exist but have not been read yet.

## Root cause

After #172, `setup()` ends with:

```lua
vim.tbl_map(function(bufnr) M.refresh_highlights(bufnr, true) end, vim.api.nvim_list_bufs())
```

`nvim_list_bufs()` returns valid-but-unloaded buffers as well (e.g. extra
files passed as CLI args, buffers restored from a session). The guard inside
`refresh_highlights` only checks `nvim_buf_is_valid`, so execution proceeds
into `nvim_buf_get_lines`, which yields `nil` for unloaded buffers, and then
crashes in `buffer_utils.lua:38` at `pairs(content)`.

<img width="889" height="150" alt="スクリーンショット 2026-05-20 1 22 30" src="https://github.com/user-attachments/assets/0246b73d-89f5-4fe2-97e7-62d6b8c3ee54" />

## Reproduction

```sh
cd /tmp && touch a.lua b.lua
nvim a.lua b.lua
```

`b.lua` is listed but not loaded when `BufReadPre` for `a.lua` triggers the
lazy load. The error appears on startup.

## Verification

- Reproduced the crash on `main` with the steps above.
- Confirmed the crash is gone with this patch applied.
- Highlights still apply correctly to the loaded buffer.

Closes #179